### PR TITLE
Only write to fasta if record name not in non_k2g

### DIFF
--- a/k2g_no_k2g_read_compare.py
+++ b/k2g_no_k2g_read_compare.py
@@ -41,8 +41,7 @@ def save_reads_only_in_k2g(index):
     db_k2g = screed.read_fasta_sequences(k2g)
     for name in db_k2g:
         if name not in record_names_no_k2g:
-            continue
-        result_fasta.write(">{}\n{}\n".format(name, db_k2g[name].sequence))
+            result_fasta.write(">{}\n{}\n".format(name, db_k2g[name].sequence))
 
 
 with Pool(12) as p:

--- a/k2g_no_k2g_read_compare.py
+++ b/k2g_no_k2g_read_compare.py
@@ -34,7 +34,7 @@ def save_reads_only_in_k2g(index):
     no_k2g = os.path.join(NO_K2G_FASTA_PATH, os.path.basename(k2g))
     record_names_no_k2g = get_record_names(no_k2g)
     filename = os.path.join(K2G_INTERSECT, os.path.basename(k2g).replace(
-        ".fasta", "_intersect.fasta"))
+        ".fasta", "_difference.fasta"))
     result_fasta = open(filename, "a")
     print(record_names_no_k2g[:5])
     print(k2g)


### PR DESCRIPTION
Looking at one of the outputs of the K2G analysis, I would expect that the Mock (non-HIV) treated cells had much fewer K2G translateable reads, i.e. the reads that are ONLY in the K2G dataset and not in the non-K2G data would be much less, but that is not the case.

E.g. here is the original coding peptides:

```
 Tue 28 Jul - 16:41  /mnt/ibm_lg/pranathi/kmer-hashing/golumbeanu2018/kmermaid/k2g_uniprot/extract_coding 
 olga@lrrr  ll *coding_reads_peptides.fasta
Permissions Size User     Group Date Modified Name
.rw-r--r--   49M pranathi czb   14 Apr  2:24  SRR5763193_GSM2687511_Mock_6h_Homo_sapiens_RNA-Seq__coding_reads_peptides.fasta
.rw-r--r--   57M pranathi czb   18 Apr  0:46  SRR5763194_GSM2687512_Mock_12h_Homo_sapiens_RNA-Seq__coding_reads_peptides.fasta
.rw-r--r--   64M pranathi czb   15 Apr 19:36  SRR5763195_GSM2687513_Mock_18h_Homo_sapiens_RNA-Seq__coding_reads_peptides.fasta
.rw-r--r--   76M pranathi czb   18 Apr 20:23  SRR5763196_GSM2687514_Mock_24h_Homo_sapiens_RNA-Seq__coding_reads_peptides.fasta
.rw-r--r--   61M pranathi czb   14 Apr 16:33  SRR5763197_GSM2687515_Mock_24h_r_Homo_sapiens_RNA-Seq__coding_reads_peptides.fasta
.rw-r--r--   63M pranathi czb   17 Apr 12:56  SRR5763198_GSM2687516_Mock_30h_Homo_sapiens_RNA-Seq__coding_reads_peptides.fasta
.rw-r--r--   24M pranathi czb   13 Apr  2:55  SRR5763199_GSM2687517_HIV_6h_Homo_sapiens_RNA-Seq__coding_reads_peptides.fasta
.rw-r--r--   70M pranathi czb   19 Apr  9:50  SRR5763200_GSM2687518_HIV_12h_Homo_sapiens_RNA-Seq__coding_reads_peptides.fasta
.rw-r--r--   56M pranathi czb   16 Apr 21:23  SRR5763201_GSM2687519_HIV_18h_Homo_sapiens_RNA-Seq__coding_reads_peptides.fasta
.rw-r--r--   61M pranathi czb   16 Apr 10:09  SRR5763202_GSM2687520_HIV_24h_Homo_sapiens_RNA-Seq__coding_reads_peptides.fasta
.rw-r--r--   42M pranathi czb   13 Apr 15:00  SRR5763203_GSM2687521_HIV_24h_r_Homo_sapiens_RNA-Seq__coding_reads_peptides.fasta
.rw-r--r--   55M pranathi czb   15 Apr  5:12  SRR5763204_GSM2687522_HIV_30h_Homo_sapiens_RNA-Seq__coding_reads_peptides.fasta
```

And here are the K2G only ones:

```
 Tue 28 Jul - 16:29  /mnt/ibm_lg/pranathi/k2g_analysis_july20 
 olga@lrrr  ll
Permissions Size User     Group Date Modified Name
.rw-r--r--   53M pranathi czb   22 Jul 23:02  SRR5763193_GSM2687511_Mock_6h_Homo_sapiens_RNA-Seq__coding_reads_peptides_clean_intersect.fasta
.rw-r--r--   62M pranathi czb   24 Jul  0:51  SRR5763194_GSM2687512_Mock_12h_Homo_sapiens_RNA-Seq__coding_reads_peptides_clean_intersect.fasta
.rw-r--r--   69M pranathi czb   23 Jul 21:24  SRR5763195_GSM2687513_Mock_18h_Homo_sapiens_RNA-Seq__coding_reads_peptides_clean_intersect.fasta
.rw-r--r--   83M pranathi czb   24 Jul 14:51  SRR5763196_GSM2687514_Mock_24h_Homo_sapiens_RNA-Seq__coding_reads_peptides_clean_intersect.fasta
.rw-r--r--   66M pranathi czb   23 Jul  7:55  SRR5763197_GSM2687515_Mock_24h_r_Homo_sapiens_RNA-Seq__coding_reads_peptides_clean_intersect.fasta
.rw-r--r--   67M pranathi czb   23 Jul 16:03  SRR5763198_GSM2687516_Mock_30h_Homo_sapiens_RNA-Seq__coding_reads_peptides_clean_intersect.fasta
.rw-r--r--   27M pranathi czb   21 Jul  4:50  SRR5763199_GSM2687517_HIV_6h_Homo_sapiens_RNA-Seq__coding_reads_peptides_clean_intersect.fasta
.rw-r--r--   77M pranathi czb   24 Jul 14:16  SRR5763200_GSM2687518_HIV_12h_Homo_sapiens_RNA-Seq__coding_reads_peptides_clean_intersect.fasta
.rw-r--r--   62M pranathi czb   23 Jul  9:04  SRR5763201_GSM2687519_HIV_18h_Homo_sapiens_RNA-Seq__coding_reads_peptides_clean_intersect.fasta
.rw-r--r--   66M pranathi czb   23 Jul 22:13  SRR5763202_GSM2687520_HIV_24h_Homo_sapiens_RNA-Seq__coding_reads_peptides_clean_intersect.fasta
.rw-r--r--   45M pranathi czb   22 Jul 20:50  SRR5763203_GSM2687521_HIV_24h_r_Homo_sapiens_RNA-Seq__coding_reads_peptides_clean_intersect.fasta
.rw-r--r--   59M pranathi czb   23 Jul  9:38  SRR5763204_GSM2687522_HIV_30h_Homo_sapiens_RNA-Seq__coding_reads_peptides_clean_intersect.fasta
```

In the first case, for example, `SRR5763193_GSM2687511_Mock_6h_Homo_sapiens_RNA-Seq__coding_reads_peptides_clean_intersect.fasta` is 49MB before filtering for only K2G reads, but after filtering, it is 53MB! I think it got bigger because there were more translateable reading frames in the non-K2G data.

Searching for one of the reads, the first one, `SRR5763193.188_SRR5763193.188_HISEQ:105:C56AGACXX:8:1305:12083:71210/1_translation_frame:_-2_jaccard:_1.0` from the file:


```
 Tue 28 Jul - 16:30  /mnt/ibm_lg/pranathi/k2g_analysis_july20 
 olga@lrrr  head SRR5763193_GSM2687511_Mock_6h_Homo_sapiens_RNA-Seq__coding_reads_peptides_clean_intersect.fasta
>SRR5763193.188_SRR5763193.188_HISEQ:105:C56AGACXX:8:1305:12083:71210/1_translation_frame:_-2_jaccard:_1.0
KLVRQVRLFQDEEIYSDLYLTVCEWPSDASKVI
>SRR5763193.323_SRR5763193.323_HISEQ:105:C56AGACXX:8:1305:17059:71181/1_translation_frame:_3_jaccard:_1.0
AMFRRKAFLHWYTGEGMDEMEFTEAESNMNDLV
>SRR5763193.586_SRR5763193.586_HISEQ:105:C56AGACXX:8:1305:7212:71485/1_translation_frame:_-3_jaccard:_1.0
KIGPQLKELNPEEGEMVEEKYQKAENMYAQIKE
>SRR5763193.859_SRR5763193.859_HISEQ:105:C56AGACXX:8:1305:16677:71299/1_translation_frame:_1_jaccard:_1.0
GNLSLPVDVTLAVFAVGAQSTEGWDFLYSKYQF
>SRR5763193.1454_SRR5763193.1454_HISEQ:105:C56AGACXX:8:1305:19511:71742/1_translation_frame:_-3_jaccard:_1.0
PACPGQPLANGPFSAGHVPCSTSRTLGSTDTIL
```

It's present in *both* the K2G and non-K2G data, so I think something went wrong in the filtering:


![Screen Shot 2020-07-28 at 4 40 33 PM](https://user-images.githubusercontent.com/806256/88740112-22eeea00-d0f1-11ea-982b-dbd4d375ed1f.png)

![Screen Shot 2020-07-28 at 4 40 40 PM](https://user-images.githubusercontent.com/806256/88740108-21252680-d0f1-11ea-9ae0-af163ff72ad0.png)

This PR changes the code to only write out to fasta if the read is not present in the non-k2g data.